### PR TITLE
Gpt 호출 API 및 프론트에서 사용방법 구현 

### DIFF
--- a/SeagullsRoom/build.gradle
+++ b/SeagullsRoom/build.gradle
@@ -32,11 +32,16 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	//lombok
 	annotationProcessor 'org.projectlombok:lombok'
+
+	//test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	//jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'

--- a/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/domain/gpt/ChatGPTResponse.java
+++ b/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/domain/gpt/ChatGPTResponse.java
@@ -1,0 +1,38 @@
+package com.new3seagull.SeagullsRoom.domain.gpt;
+
+import lombok.Getter;
+
+
+import java.util.List;
+
+@Getter
+public class ChatGPTResponse {
+    private String id;
+    private String object;
+    private int created;
+    private String model;
+    private List<Choice> choices;
+    private Usage usage;
+
+    @Getter
+    public static class Choice {
+        private int index;
+        private Message message;
+        private String finish_reason;
+
+    }
+    @Getter
+    public static class Message {
+        private String role;
+        private String content;
+
+    }
+
+    public static class Usage {
+        private int prompt_tokens;
+        private int completion_tokens;
+        private int total_tokens;
+
+    }
+
+}

--- a/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/domain/gpt/controller/ChatGPTController.java
+++ b/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/domain/gpt/controller/ChatGPTController.java
@@ -1,0 +1,46 @@
+package com.new3seagull.SeagullsRoom.domain.gpt.controller;
+
+
+import com.new3seagull.SeagullsRoom.domain.gpt.ChatGPTRequest;
+import com.new3seagull.SeagullsRoom.domain.gpt.ChatGPTResponse;
+import com.new3seagull.SeagullsRoom.global.util.ImageUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/v1/gpt")
+@RequiredArgsConstructor
+public class ChatGPTController {
+    @Value("${openai.model}")
+    private String model;
+
+    @Value("${openai.api.url}")
+    private String apiURL;
+
+    private final RestTemplate restTemplate;
+
+
+    @PostMapping("/chat")
+    public String requestGpt(@RequestPart("image") MultipartFile imageFile) {
+        String responseContent = null;
+        try {
+            String base64Image = ImageUtils.encodeImageToBase64(imageFile);
+            ChatGPTRequest request = new ChatGPTRequest(model, base64Image);
+            ChatGPTResponse chatGPTResponse = restTemplate.postForObject(apiURL, request, ChatGPTResponse.class);
+            responseContent = chatGPTResponse.getChoices().get(0).getMessage().getContent().toString();
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return responseContent;
+    }
+}

--- a/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/domain/gpt/controller/ChatGPTController.java
+++ b/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/domain/gpt/controller/ChatGPTController.java
@@ -1,8 +1,8 @@
 package com.new3seagull.SeagullsRoom.domain.gpt.controller;
 
 
-import com.new3seagull.SeagullsRoom.domain.gpt.ChatGPTRequest;
-import com.new3seagull.SeagullsRoom.domain.gpt.ChatGPTResponse;
+import com.new3seagull.SeagullsRoom.domain.gpt.dto.ChatGPTRequest;
+import com.new3seagull.SeagullsRoom.domain.gpt.dto.ChatGPTResponse;
 import com.new3seagull.SeagullsRoom.global.util.ImageUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,8 +12,6 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
 
 @RestController
 @RequestMapping("/api/v1/gpt")

--- a/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/domain/gpt/dto/ChatGPTRequest.java
+++ b/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/domain/gpt/dto/ChatGPTRequest.java
@@ -1,0 +1,19 @@
+package com.new3seagull.SeagullsRoom.domain.gpt.dto;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class ChatGPTRequest {
+    private String model;
+    private List<GptRequestMessage> messages;
+
+    public ChatGPTRequest(String model, String base64image) {
+        this.model = model;
+        this.messages = new ArrayList<>();
+        List<Object> list = List.of(new ImgContent("image_url",new ImgContent.Img("data:image/jpeg;base64," + base64image)), new TextContent("text", "다음 사진이 공부와 관련이 있으면 1을 없으면 0을 출력해 줘"));
+        this.messages.add(new GptRequestMessage("user", list));
+    }
+}

--- a/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/domain/gpt/dto/ChatGPTResponse.java
+++ b/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/domain/gpt/dto/ChatGPTResponse.java
@@ -1,4 +1,4 @@
-package com.new3seagull.SeagullsRoom.domain.gpt;
+package com.new3seagull.SeagullsRoom.domain.gpt.dto;
 
 import lombok.Getter;
 

--- a/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/domain/gpt/dto/GptRequestMessage.java
+++ b/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/domain/gpt/dto/GptRequestMessage.java
@@ -1,0 +1,15 @@
+package com.new3seagull.SeagullsRoom.domain.gpt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GptRequestMessage {
+    private String role;
+    private List<Object> content;
+}

--- a/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/domain/gpt/dto/ImgContent.java
+++ b/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/domain/gpt/dto/ImgContent.java
@@ -1,0 +1,22 @@
+package com.new3seagull.SeagullsRoom.domain.gpt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImgContent {
+    private String type;
+    private Img image_url;
+
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Img {
+        private String url;
+    }
+}

--- a/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/domain/gpt/dto/TextContent.java
+++ b/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/domain/gpt/dto/TextContent.java
@@ -1,0 +1,13 @@
+package com.new3seagull.SeagullsRoom.domain.gpt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TextContent {
+    private String type;
+    private String text;
+}

--- a/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/global/config/ChatGPTConfig.java
+++ b/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/global/config/ChatGPTConfig.java
@@ -1,0 +1,23 @@
+package com.new3seagull.SeagullsRoom.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class ChatGPTConfig {
+
+    @Value("${openai.api.key}")
+    private String secretKey;
+
+    @Bean(name = "GPTRestTemplate")
+    public RestTemplate gptRestTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.getInterceptors().add(((request, body, execution) -> {
+            request.getHeaders().add("Authorization", "Bearer " + secretKey);
+            return execution.execute(request, body);
+        }));
+        return restTemplate;
+    }
+}

--- a/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/global/config/SecurityConfig.java
+++ b/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/global/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
         //경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/", "/join", "/api/v1/users", "/auth.html", "/login.html", "/signup.html", "/main.html", "/h2-console/**", "/favicon.ico", "/css/**", "/js/**").permitAll()
+                        .requestMatchers("/","/gpt.html", "/join", "/api/v1/users", "/auth.html", "/login.html", "/signup.html", "/main.html", "/h2-console/**", "/favicon.ico", "/css/**", "/js/**").permitAll()
                         .requestMatchers("/admin").hasRole("ADMIN")
                         .anyRequest().authenticated());
         //JWTFilter 등록

--- a/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/global/util/ImageUtils.java
+++ b/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/global/util/ImageUtils.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.util.Base64;
 
 public class ImageUtils {
-    public static String encodeImageToBase64(MultipartFile imageFile) throws IOException, IOException {
+    public static String encodeImageToBase64(MultipartFile imageFile) throws IOException {
         byte[] fileContent = imageFile.getBytes();
         return Base64.getEncoder().encodeToString(fileContent);
     }

--- a/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/global/util/ImageUtils.java
+++ b/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/global/util/ImageUtils.java
@@ -1,0 +1,13 @@
+package com.new3seagull.SeagullsRoom.global.util;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Base64;
+
+public class ImageUtils {
+    public static String encodeImageToBase64(MultipartFile imageFile) throws IOException, IOException {
+        byte[] fileContent = imageFile.getBytes();
+        return Base64.getEncoder().encodeToString(fileContent);
+    }
+}

--- a/SeagullsRoom/src/main/resources/application.yml
+++ b/SeagullsRoom/src/main/resources/application.yml
@@ -15,6 +15,11 @@ spring:
 
   jwt:
     secret: vmfhaltmskdlstkfkdgodyroqkfwkdbalroqkfwkdbalaaaaaaaaaaaaaaaabbbbb
+openai:
+  model: gpt-4o
+  api:
+    key: token
+    url: https://api.openai.com/v1/chat/completions
 
 ---
 

--- a/SeagullsRoom/src/main/resources/static/gpt.html
+++ b/SeagullsRoom/src/main/resources/static/gpt.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ChatGPT Image Upload</title>
+</head>
+<body>
+<h1>Upload an Image to ChatGPT</h1>
+<form id="imageForm">
+    <input type="file" id="imageFile" name="imageFile" accept="image/*" required>
+    <button type="submit">Upload and Submit</button>
+</form>
+
+<h2>Response:</h2>
+<pre id="responseContent"></pre>
+
+<script src="js/gpt.js"></script>
+</body>
+</html>

--- a/SeagullsRoom/src/main/resources/static/js/gpt.js
+++ b/SeagullsRoom/src/main/resources/static/js/gpt.js
@@ -1,0 +1,30 @@
+//Gpt 요청 보내기
+document.getElementById('imageForm').addEventListener('submit', function(event) {
+    event.preventDefault();
+
+    const imageFileInput = document.getElementById('imageFile');
+    const imageFile = imageFileInput.files[0];
+
+    if (imageFile) {
+        const formData = new FormData();
+        formData.append('image', imageFile);
+        const jwtToken = localStorage.getItem('jwtToken');
+
+        fetch('http://localhost:8080/api/v1/gpt/chat', {
+            method: 'POST',
+            headers: {
+                'Authorization': `${jwtToken}`
+            },
+            body: formData
+        })
+            .then(response => response.text())
+            .then(data => {
+                document.getElementById('responseContent').textContent = data;
+            })
+            .catch(error => {
+                console.error('Error:', error);
+            });
+    } else {
+        alert('Please select an image file.');
+    }
+});

--- a/SeagullsRoom/src/main/resources/static/main.html
+++ b/SeagullsRoom/src/main/resources/static/main.html
@@ -5,6 +5,7 @@
     <title>Greeting</title>
 </head>
 <body>
+<a href = "http://localhost:8080/gpt.html">gpt</a>
 <div id="greeting"></div>
 
 <script>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #20 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/20-gpt-api -> develop

### 변경 사항 설명
1. GPT API를 요청하는 엔드포인트와, GPT Config 설정 , GPT 요청, 응답을 위한 dto를 구현했습니다.
2. gpt요청을 위한 html, js를 구현했습니다.

### 테스트 결과


![test](https://github.com/user-attachments/assets/ebb249c7-a1ca-45b8-a218-d0ea50918ab4)

위 이미지를 전송했을 때 아래와 같이 공부와 관련이 있어 1을 return했습니다.
공부와 관련이 없으면 0을 리턴합니다.

<img width="459" alt="스크린샷 2024-07-19 오후 6 05 04" src="https://github.com/user-attachments/assets/5b0cb605-e6bd-4240-bcb1-3c99f4a2a111">



