### PR TITLE
token null 무한으로 찍히는 버그 수정

### DIFF
--- a/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/global/jwt/JWTFilter.java
+++ b/SeagullsRoom/src/main/java/com/new3seagull/SeagullsRoom/global/jwt/JWTFilter.java
@@ -31,8 +31,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
         //Authorization 헤더 검증
         if (authorization == null || !authorization.startsWith("Bearer ")) {
-
-            System.out.println("token null");
+            
             filterChain.doFilter(request, response);
 
             //조건이 해당되면 메소드 종료 (필수)

--- a/SeagullsRoom/src/main/resources/application.yml
+++ b/SeagullsRoom/src/main/resources/application.yml
@@ -59,5 +59,3 @@ spring:
   sql:
     init:
       mode: never # init sql 실행 x
-
-


### PR DESCRIPTION
## #️⃣연관된 이슈

#22

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) bug/22-token-null -> develop

### 변경 사항 설명
token null 계속 찍히는 버그는 크롬에서 자동 요청이 여러 번 나가서 생기는 버그였음.
print 문법을 제거해서 신경 안 쓰이게 수정
